### PR TITLE
Fixes issue #14 with last set volume not getting saved

### DIFF
--- a/scripts/volume.js
+++ b/scripts/volume.js
@@ -170,7 +170,7 @@ var BandcampVolume = {
 
         // Retrieve last saved options from localStorage (Saving them in localStorage means they can be loaded synchronously, and then applied while the page is still loading)
         // The default settings are both true unless the localStorage values are set or the chrome.storage value is updated (This will auto update localStorage and the local variable via _syncVolOptions)
-        //bcv._saveVol = localStorage.getItem("saveVolume") || true
+        bcv._saveVol = localStorage.getItem("saveVolume") || true;
 
         // Create input slider and set attributes
         bcv._range = document.createElement("input");


### PR DESCRIPTION
For some reason the line (173) that initialized the saveVolume variable had been commented out, so it was never pulling the last saved volume from local storage. Simply uncommenting this seemed to fix the issue. 